### PR TITLE
Remove rtmbot.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-rtmbot.conf
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,12 @@ RUN git clone https://github.com/slackhq/python-rtmbot
 WORKDIR python-rtmbot
 RUN python3 -m pip install -r requirements.txt
 
-COPY rtmbot.conf .
 RUN mkdir plugins/os_command_injection
 COPY constant.py plugins/os_command_injection
 COPY docker.py plugins/os_command_injection
 COPY code_runner.py plugins/os_command_injection
 COPY os_command_injection.py plugins/os_command_injection
 
-CMD ["./rtmbot.py"]
+COPY start.sh .
+
+CMD ["./start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo -e "DEBUG: False\n\nSLACK_TOKEN: $SLACK_TOKEN" > rtmbot.conf
+./rtmbot.py > out.log 2> err.log


### PR DESCRIPTION
rtmbot.confファイルをCOPYするとSLACK TOKENが漏れてしまう