### PR TITLE
bash用コンテナのビルド時にユーザ入力の待機をする問題を修正

### DIFF
--- a/langs/bash/Dockerfile
+++ b/langs/bash/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /tmp && \
 
 RUN apt install -y bc dc zsh w3m curl git nkf software-properties-common
 
-RUN apt-add-repository ppa:brightbox/ruby-ng && \
+RUN apt-add-repository ppa:brightbox/ruby-ng -y && \
     apt update && \
     apt install -y ruby2.5
 


### PR DESCRIPTION
コンテナのビルド中、ユーザの入力を待機してしまいビルドに失敗してしまう問題があったので、修正しました。